### PR TITLE
feat: Add WebRTC connection for viewing opponent boards (#8)

### DIFF
--- a/app/game/OpponentBoard.tsx
+++ b/app/game/OpponentBoard.tsx
@@ -1,0 +1,44 @@
+'use client';
+
+import styles from './multiplayer.module.css';
+import { boardConfigs, BoardType } from './boardConfigs';
+import type { OpponentState } from './useMultiplayer';
+
+const TILE_COLORS: Record<string, string> = {
+  forest: '#5a7a3d',
+  village: '#8b4f4f',
+  farm: '#d4a74e',
+  water: '#4a7ba7',
+  monster: '#6b4a7a',
+};
+
+export default function OpponentBoard({ opponent }: { opponent: OpponentState }) {
+  const boardType = (opponent.boardType || 'default') as BoardType;
+  const config = boardConfigs[boardType] || boardConfigs['default'];
+
+  const cells = [];
+  for (let row = 0; row < 11; row++) {
+    for (let col = 0; col < 11; col++) {
+      const sel = opponent.selections.find(s => s.row === row && s.column === col);
+      const isBlocked = config.blockedSpaces.some(b => b[0] === col && b[1] === row);
+      const isMountain = config.mountains.some(m => m[0] === col && m[1] === row);
+
+      let bg = '#d4c4a8';
+      if (sel) bg = TILE_COLORS[sel.type] || bg;
+      else if (isBlocked) bg = 'rgb(80,70,60)';
+      else if (isMountain) bg = 'rgb(125,120,120)';
+
+      cells.push(
+        <div key={`${row}-${col}`} style={{ background: bg }} className={styles.miniCell} />
+      );
+    }
+  }
+
+  return (
+    <div className={styles.opponentCard}>
+      <div className={styles.opponentName}>{opponent.name || 'Unknown Cartographer'}</div>
+      <div className={styles.miniBoard}>{cells}</div>
+      <div className={styles.opponentCoins}>🪙 {opponent.coinCount}</div>
+    </div>
+  );
+}

--- a/app/game/RoomPanel.tsx
+++ b/app/game/RoomPanel.tsx
@@ -1,0 +1,67 @@
+'use client';
+
+import { useState } from 'react';
+import styles from './multiplayer.module.css';
+
+type Props = {
+  roomId: string | null;
+  connected: boolean;
+  error: string | null;
+  opponentCount: number;
+  onCreateRoom: () => void;
+  onJoinRoom: (code: string) => void;
+  onLeaveRoom: () => void;
+};
+
+export default function RoomPanel({ roomId, connected, error, opponentCount, onCreateRoom, onJoinRoom, onLeaveRoom }: Props) {
+  const [joinCode, setJoinCode] = useState('');
+  const [showPanel, setShowPanel] = useState(false);
+
+  if (connected && roomId) {
+    return (
+      <div className={styles.roomPanel}>
+        <div className={styles.roomInfo}>
+          <span className={styles.roomLabel}>Room:</span>
+          <span className={styles.roomCode}>{roomId}</span>
+          <span className={styles.peerCount}>{opponentCount} opponent{opponentCount !== 1 ? 's' : ''}</span>
+          <button className={styles.leaveBtn} onClick={onLeaveRoom}>Leave</button>
+        </div>
+      </div>
+    );
+  }
+
+  if (!showPanel) {
+    return (
+      <div className={styles.roomPanel}>
+        <button className={styles.multiplayerBtn} onClick={() => setShowPanel(true)}>
+          ⚔️ Multiplayer
+        </button>
+      </div>
+    );
+  }
+
+  return (
+    <div className={styles.roomPanel}>
+      <div className={styles.roomActions}>
+        <button className={styles.createBtn} onClick={() => { onCreateRoom(); }}>
+          Create Game
+        </button>
+        <div className={styles.joinRow}>
+          <input
+            type="text"
+            maxLength={6}
+            placeholder="ROOM CODE"
+            value={joinCode}
+            onChange={e => setJoinCode(e.target.value.toUpperCase())}
+            className={styles.codeInput}
+          />
+          <button className={styles.joinBtn} onClick={() => onJoinRoom(joinCode)}>
+            Join
+          </button>
+        </div>
+        <button className={styles.cancelBtn} onClick={() => setShowPanel(false)}>Cancel</button>
+      </div>
+      {error && <p className={styles.error}>{error}</p>}
+    </div>
+  );
+}

--- a/app/game/[id]/page.tsx
+++ b/app/game/[id]/page.tsx
@@ -18,6 +18,10 @@ import {
 } from '../../lib/gameStorage';
 import OpponentsPanel from '../OpponentsPanel';
 import { GAME_PIECES, GamePiece, rotatePiece, flipPiece } from '../pieces';
+import { useMultiplayer } from '../useMultiplayer';
+import RoomPanel from '../RoomPanel';
+import OpponentBoard from '../OpponentBoard';
+import mpStyles from '../multiplayer.module.css';
 
 type SeasonScoreType = {
   edictOne: number;
@@ -120,6 +124,9 @@ export default function GamePage({ params }: { params: { id: string } }) {
   const [hoverCell, setHoverCell] = useState<[number, number] | null>(null);
   const [piecesOpen, setPiecesOpen] = useState(false);
 
+  // Multiplayer
+  const { roomId, connected, opponents, error: mpError, createRoom, joinRoom, leaveRoom, broadcastState } = useMultiplayer();
+
   const handleRotate = useCallback(() => {
     if (currentShape.length > 0) {
       setCurrentShape(prev => rotatePiece(prev));
@@ -201,6 +208,18 @@ export default function GamePage({ params }: { params: { id: string } }) {
       return newState;
     });
   }
+
+  // Broadcast state to multiplayer peers when game state changes
+  useEffect(() => {
+    if (connected && gameState && meta) {
+      broadcastState({
+        name: meta.cartographer || 'Unknown',
+        selections: gameState.selections,
+        coinCount: gameState.coinCount,
+        boardType: meta.boardType,
+      });
+    }
+  }, [connected, gameState, meta, broadcastState]);
 
   if (!loaded || !meta || !gameState) return null;
 
@@ -364,6 +383,17 @@ export default function GamePage({ params }: { params: { id: string } }) {
         {/* Players / Opponents */}
         <OpponentsPanel meta={meta} onMetaChange={setMeta} />
 
+        {/* Multiplayer Room */}
+        <RoomPanel
+          roomId={roomId}
+          connected={connected}
+          error={mpError}
+          opponentCount={opponents.length}
+          onCreateRoom={createRoom}
+          onJoinRoom={joinRoom}
+          onLeaveRoom={leaveRoom}
+        />
+
         <main className={styles.mainContent}>
           <div className={styles.boardContainer}>
             <div className={styles.tileBoard} onMouseLeave={() => setHoverCell(null)}>
@@ -445,6 +475,18 @@ export default function GamePage({ params }: { params: { id: string } }) {
               {seasonOneScore + seasonTwoScore + seasonThreeScore + seasonFourScore}
             </div>
           </div>
+
+          {/* Opponent Boards */}
+          {opponents.length > 0 && (
+            <div className={mpStyles.opponentsSection}>
+              <div className={mpStyles.opponentsTitle}>Opponent Boards</div>
+              <div className={mpStyles.opponentsGrid}>
+                {opponents.map(opp => (
+                  <OpponentBoard key={opp.peerId} opponent={opp} />
+                ))}
+              </div>
+            </div>
+          )}
         </main>
       </div>
     </div>

--- a/app/game/multiplayer.module.css
+++ b/app/game/multiplayer.module.css
@@ -1,0 +1,194 @@
+/* Room Panel */
+.roomPanel {
+  margin-bottom: 1rem;
+  padding: 0.75rem;
+  border: 2px solid var(--border-brown);
+  border-radius: 4px;
+  background: var(--parchment-light);
+}
+
+.multiplayerBtn {
+  width: 100%;
+  padding: 0.5rem;
+  border: 2px solid var(--border-brown);
+  background: var(--parchment-bg);
+  color: var(--border-dark);
+  border-radius: 4px;
+  cursor: pointer;
+  font-weight: bold;
+  font-size: 0.9rem;
+  transition: all 0.2s;
+}
+
+.multiplayerBtn:hover {
+  background: var(--border-brown);
+  color: var(--parchment-light);
+}
+
+.roomInfo {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+}
+
+.roomLabel {
+  font-weight: bold;
+  font-size: 0.8rem;
+  text-transform: uppercase;
+  color: var(--border-dark);
+}
+
+.roomCode {
+  font-family: monospace;
+  font-size: 1.1rem;
+  font-weight: bold;
+  color: var(--border-dark);
+  background: var(--parchment-bg);
+  padding: 0.2rem 0.5rem;
+  border: 1px solid var(--border-brown);
+  border-radius: 3px;
+  letter-spacing: 2px;
+}
+
+.peerCount {
+  font-size: 0.8rem;
+  color: var(--border-brown);
+}
+
+.leaveBtn, .cancelBtn {
+  padding: 0.3rem 0.8rem;
+  border: 1px solid var(--border-brown);
+  background: transparent;
+  color: var(--border-dark);
+  border-radius: 3px;
+  cursor: pointer;
+  font-size: 0.8rem;
+}
+
+.leaveBtn:hover, .cancelBtn:hover {
+  background: var(--border-brown);
+  color: var(--parchment-light);
+}
+
+.roomActions {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.createBtn, .joinBtn {
+  padding: 0.5rem 1rem;
+  border: 2px solid var(--border-brown);
+  background: var(--border-brown);
+  color: var(--parchment-light);
+  border-radius: 4px;
+  cursor: pointer;
+  font-weight: bold;
+  font-size: 0.85rem;
+  transition: all 0.2s;
+}
+
+.createBtn:hover, .joinBtn:hover {
+  background: var(--border-dark);
+  border-color: var(--border-dark);
+}
+
+.joinRow {
+  display: flex;
+  gap: 0.5rem;
+}
+
+.codeInput {
+  flex: 1;
+  padding: 0.5rem;
+  border: 2px solid var(--border-brown);
+  border-radius: 4px;
+  background: white;
+  font-family: monospace;
+  font-size: 1rem;
+  text-align: center;
+  letter-spacing: 3px;
+  text-transform: uppercase;
+  color: var(--border-dark);
+}
+
+.codeInput:focus {
+  outline: none;
+  border-color: var(--border-dark);
+}
+
+.error {
+  margin-top: 0.5rem;
+  color: #8b4f4f;
+  font-size: 0.85rem;
+}
+
+/* Opponent Boards */
+.opponentsSection {
+  margin-top: 1rem;
+  padding: 1rem;
+  border: 2px solid var(--border-brown);
+  border-radius: 4px;
+  background: var(--parchment-light);
+}
+
+.opponentsTitle {
+  font-weight: bold;
+  font-size: 0.85rem;
+  text-transform: uppercase;
+  color: var(--border-dark);
+  letter-spacing: 0.5px;
+  margin-bottom: 0.75rem;
+}
+
+.opponentsGrid {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+}
+
+.opponentCard {
+  background: var(--parchment-bg);
+  border: 2px solid var(--border-brown);
+  border-radius: 4px;
+  padding: 0.5rem;
+  width: 160px;
+}
+
+.opponentName {
+  font-weight: bold;
+  font-size: 0.75rem;
+  color: var(--border-dark);
+  margin-bottom: 0.25rem;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.miniBoard {
+  display: grid;
+  grid-template-columns: repeat(11, 1fr);
+  grid-template-rows: repeat(11, 1fr);
+  gap: 0px;
+  aspect-ratio: 1 / 1;
+  width: 100%;
+  border: 1px solid var(--border-brown);
+}
+
+.miniCell {
+  aspect-ratio: 1;
+}
+
+.opponentCoins {
+  font-size: 0.75rem;
+  color: var(--border-dark);
+  margin-top: 0.25rem;
+  text-align: right;
+}
+
+@media (max-width: 768px) {
+  .opponentCard {
+    width: 130px;
+  }
+}

--- a/app/game/useMultiplayer.ts
+++ b/app/game/useMultiplayer.ts
@@ -1,0 +1,297 @@
+'use client';
+
+import { useState, useEffect, useRef, useCallback } from 'react';
+
+export type OpponentState = {
+  peerId: string;
+  name: string;
+  selections: Array<{ row: number; column: number; type: string }>;
+  coinCount: number;
+  boardType: string;
+};
+
+type PeerConnection = {
+  pc: RTCPeerConnection;
+  dc: RTCDataChannel | null;
+  peerId: string;
+};
+
+function generateId(): string {
+  return Math.random().toString(36).substring(2, 10);
+}
+
+function generateRoomCode(): string {
+  const chars = 'ABCDEFGHJKLMNPQRSTUVWXYZ23456789';
+  let code = '';
+  for (let i = 0; i < 6; i++) code += chars[Math.floor(Math.random() * chars.length)];
+  return code;
+}
+
+const ICE_SERVERS = [{ urls: 'stun:stun.l.google.com:19302' }];
+
+export function useMultiplayer() {
+  const [roomId, setRoomId] = useState<string | null>(null);
+  const [connected, setConnected] = useState(false);
+  const [opponents, setOpponents] = useState<Map<string, OpponentState>>(new Map());
+  const [error, setError] = useState<string | null>(null);
+
+  const peerId = useRef(generateId());
+  const peers = useRef(new Map<string, PeerConnection>());
+  const pollTimer = useRef<ReturnType<typeof setInterval> | null>(null);
+  const lastTimestamp = useRef(0);
+  const currentRoomId = useRef<string | null>(null);
+  const myState = useRef<object | null>(null);
+
+  const broadcastState = useCallback((state: object) => {
+    myState.current = state;
+    const msg = JSON.stringify(state);
+    Array.from(peers.current.values()).forEach(peer => {
+      if (peer.dc && peer.dc.readyState === 'open') {
+        peer.dc.send(msg);
+      }
+    });
+  }, []);
+
+  const handleDataMessage = useCallback((peerId: string, data: string) => {
+    try {
+      const state = JSON.parse(data) as OpponentState;
+      state.peerId = peerId;
+      setOpponents(prev => {
+        const next = new Map(prev);
+        next.set(peerId, state);
+        return next;
+      });
+    } catch { /* ignore */ }
+  }, []);
+
+  const setupDataChannel = useCallback((dc: RTCDataChannel, remotePeerId: string) => {
+    dc.onopen = () => {
+      // Send current state when channel opens
+      if (myState.current) dc.send(JSON.stringify(myState.current));
+    };
+    dc.onmessage = (e) => handleDataMessage(remotePeerId, e.data);
+    dc.onclose = () => {
+      setOpponents(prev => {
+        const next = new Map(prev);
+        next.delete(remotePeerId);
+        return next;
+      });
+    };
+  }, [handleDataMessage]);
+
+  const createPeerConnection = useCallback(async (remotePeerId: string, isInitiator: boolean, room: string) => {
+    if (peers.current.has(remotePeerId)) return;
+
+    const pc = new RTCPeerConnection({ iceServers: ICE_SERVERS });
+    const entry: PeerConnection = { pc, dc: null, peerId: remotePeerId };
+    peers.current.set(remotePeerId, entry);
+
+    pc.onicecandidate = (e) => {
+      if (e.candidate) {
+        fetch(`/api/signal?room=${room}`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            action: 'signal',
+            peerId: peerId.current,
+            message: { type: 'ice-candidate', to: remotePeerId, data: e.candidate }
+          })
+        });
+      }
+    };
+
+    pc.onconnectionstatechange = () => {
+      if (pc.connectionState === 'failed' || pc.connectionState === 'disconnected') {
+        peers.current.delete(remotePeerId);
+        setOpponents(prev => {
+          const next = new Map(prev);
+          next.delete(remotePeerId);
+          return next;
+        });
+      }
+    };
+
+    if (isInitiator) {
+      const dc = pc.createDataChannel('gameState');
+      entry.dc = dc;
+      setupDataChannel(dc, remotePeerId);
+
+      const offer = await pc.createOffer();
+      await pc.setLocalDescription(offer);
+
+      await fetch(`/api/signal?room=${room}`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          action: 'signal',
+          peerId: peerId.current,
+          message: { type: 'offer', to: remotePeerId, data: offer }
+        })
+      });
+    } else {
+      pc.ondatachannel = (e) => {
+        entry.dc = e.channel;
+        setupDataChannel(e.channel, remotePeerId);
+      };
+    }
+  }, [setupDataChannel]);
+
+  const handleSignalMessage = useCallback(async (msg: { from: string; type: string; data: any }, room: string) => {
+    if (msg.type === 'join') {
+      // New peer joined - initiator is the one with smaller peerId
+      if (peerId.current < msg.from) {
+        await createPeerConnection(msg.from, true, room);
+      }
+      return;
+    }
+
+    if (msg.type === 'leave') {
+      const peer = peers.current.get(msg.from);
+      if (peer) {
+        peer.pc.close();
+        peers.current.delete(msg.from);
+        setOpponents(prev => {
+          const next = new Map(prev);
+          next.delete(msg.from);
+          return next;
+        });
+      }
+      return;
+    }
+
+    if (msg.type === 'offer') {
+      await createPeerConnection(msg.from, false, room);
+      const peer = peers.current.get(msg.from);
+      if (!peer) return;
+
+      await peer.pc.setRemoteDescription(new RTCSessionDescription(msg.data));
+      const answer = await peer.pc.createAnswer();
+      await peer.pc.setLocalDescription(answer);
+
+      await fetch(`/api/signal?room=${room}`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          action: 'signal',
+          peerId: peerId.current,
+          message: { type: 'answer', to: msg.from, data: answer }
+        })
+      });
+    }
+
+    if (msg.type === 'answer') {
+      const peer = peers.current.get(msg.from);
+      if (peer) await peer.pc.setRemoteDescription(new RTCSessionDescription(msg.data));
+    }
+
+    if (msg.type === 'ice-candidate') {
+      const peer = peers.current.get(msg.from);
+      if (peer) await peer.pc.addIceCandidate(new RTCIceCandidate(msg.data));
+    }
+  }, [createPeerConnection]);
+
+  const startPolling = useCallback((room: string) => {
+    if (pollTimer.current) clearInterval(pollTimer.current);
+    lastTimestamp.current = Date.now() - 5000;
+
+    pollTimer.current = setInterval(async () => {
+      try {
+        const res = await fetch(
+          `/api/signal?room=${room}&peerId=${peerId.current}&since=${lastTimestamp.current}`
+        );
+        if (!res.ok) return;
+        const data = await res.json();
+        lastTimestamp.current = data.timestamp;
+
+        for (const msg of data.messages) {
+          await handleSignalMessage(msg, room);
+        }
+      } catch { /* ignore */ }
+    }, 1500);
+  }, [handleSignalMessage]);
+
+  const createRoom = useCallback(async () => {
+    const code = generateRoomCode();
+    try {
+      const res = await fetch(`/api/signal?room=${code}`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ action: 'create', peerId: peerId.current })
+      });
+      if (!res.ok) throw new Error('Failed to create room');
+      currentRoomId.current = code;
+      setRoomId(code);
+      setConnected(true);
+      setError(null);
+      startPolling(code);
+    } catch (e) {
+      setError('Failed to create room');
+    }
+  }, [startPolling]);
+
+  const joinRoom = useCallback(async (code: string) => {
+    const room = code.toUpperCase().trim();
+    if (room.length !== 6) { setError('Room code must be 6 characters'); return; }
+    try {
+      const res = await fetch(`/api/signal?room=${room}`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ action: 'join', peerId: peerId.current })
+      });
+      if (!res.ok) throw new Error('Room not found');
+      const data = await res.json();
+      currentRoomId.current = room;
+      setRoomId(room);
+      setConnected(true);
+      setError(null);
+      startPolling(room);
+
+      // Connect to existing peers
+      for (const existingPeer of data.peers) {
+        if (existingPeer !== peerId.current && peerId.current < existingPeer) {
+          await createPeerConnection(existingPeer, true, room);
+        }
+      }
+    } catch {
+      setError('Room not found');
+    }
+  }, [startPolling, createPeerConnection]);
+
+  const leaveRoom = useCallback(async () => {
+    if (currentRoomId.current) {
+      await fetch(`/api/signal?room=${currentRoomId.current}`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ action: 'leave', peerId: peerId.current })
+      }).catch(() => {});
+    }
+    if (pollTimer.current) clearInterval(pollTimer.current);
+    Array.from(peers.current.values()).forEach(peer => peer.pc.close());
+    peers.current.clear();
+    currentRoomId.current = null;
+    setRoomId(null);
+    setConnected(false);
+    setOpponents(new Map());
+    setError(null);
+  }, []);
+
+  // Cleanup on unmount
+  useEffect(() => {
+    return () => {
+      if (pollTimer.current) clearInterval(pollTimer.current);
+      Array.from(peers.current.values()).forEach(peer => peer.pc.close());
+    };
+  }, []);
+
+  return {
+    roomId,
+    connected,
+    opponents: Array.from(opponents.values()),
+    error,
+    peerId: peerId.current,
+    createRoom,
+    joinRoom,
+    leaveRoom,
+    broadcastState,
+  };
+}

--- a/pages/api/signal.ts
+++ b/pages/api/signal.ts
@@ -1,0 +1,109 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+
+type SignalMessage = {
+  from: string;
+  to?: string;
+  type: 'offer' | 'answer' | 'ice-candidate' | 'join' | 'leave';
+  data: unknown;
+  timestamp: number;
+};
+
+type Room = {
+  peers: Map<string, number>; // peerId -> last seen timestamp
+  messages: SignalMessage[];
+};
+
+const rooms = new Map<string, Room>();
+
+// Clean up stale rooms/peers every 5 minutes
+const PEER_TIMEOUT = 60_000;
+const MSG_TTL = 30_000;
+
+function cleanRoom(room: Room) {
+  const now = Date.now();
+  room.messages = room.messages.filter(m => now - m.timestamp < MSG_TTL);
+  Array.from(room.peers.entries()).forEach(([peer, ts]) => {
+    if (now - ts > PEER_TIMEOUT) room.peers.delete(peer);
+  });
+}
+
+export default function handler(req: NextApiRequest, res: NextApiResponse) {
+  const { method } = req;
+  const roomId = (req.query.room as string || '').toUpperCase();
+
+  if (!roomId) return res.status(400).json({ error: 'room required' });
+
+  if (method === 'POST') {
+    const { action, peerId, message } = req.body;
+
+    if (!peerId) return res.status(400).json({ error: 'peerId required' });
+
+    if (action === 'create') {
+      if (!rooms.has(roomId)) {
+        rooms.set(roomId, { peers: new Map(), messages: [] });
+      }
+      const room = rooms.get(roomId)!;
+      room.peers.set(peerId, Date.now());
+      room.messages.push({
+        from: peerId, type: 'join', data: null, timestamp: Date.now()
+      });
+      return res.json({ ok: true, peers: Array.from(room.peers.keys()) });
+    }
+
+    if (action === 'join') {
+      const room = rooms.get(roomId);
+      if (!room) return res.status(404).json({ error: 'room not found' });
+      room.peers.set(peerId, Date.now());
+      room.messages.push({
+        from: peerId, type: 'join', data: null, timestamp: Date.now()
+      });
+      return res.json({ ok: true, peers: Array.from(room.peers.keys()) });
+    }
+
+    if (action === 'signal') {
+      const room = rooms.get(roomId);
+      if (!room) return res.status(404).json({ error: 'room not found' });
+      room.peers.set(peerId, Date.now());
+      if (message) {
+        room.messages.push({ ...message, from: peerId, timestamp: Date.now() });
+      }
+      return res.json({ ok: true });
+    }
+
+    if (action === 'leave') {
+      const room = rooms.get(roomId);
+      if (room) {
+        room.peers.delete(peerId);
+        room.messages.push({
+          from: peerId, type: 'leave', data: null, timestamp: Date.now()
+        });
+        if (room.peers.size === 0) rooms.delete(roomId);
+      }
+      return res.json({ ok: true });
+    }
+
+    return res.status(400).json({ error: 'unknown action' });
+  }
+
+  if (method === 'GET') {
+    const peerId = req.query.peerId as string;
+    const since = parseInt(req.query.since as string || '0', 10);
+    const room = rooms.get(roomId);
+    if (!room) return res.status(404).json({ error: 'room not found' });
+
+    cleanRoom(room);
+    if (peerId) room.peers.set(peerId, Date.now());
+
+    const messages = room.messages.filter(
+      m => m.timestamp > since && m.from !== peerId && (!m.to || m.to === peerId)
+    );
+
+    return res.json({
+      peers: Array.from(room.peers.keys()),
+      messages,
+      timestamp: Date.now()
+    });
+  }
+
+  res.status(405).end();
+}


### PR DESCRIPTION
Implements WebRTC peer-to-peer connections for viewing opponent game boards in real-time.

## Changes
- Room system with short game codes (create/join)
- WebRTC data channels for real-time board state sharing
- Signaling server via Next.js API route
- Miniature read-only opponent board viewers
- Solo play preserved - multiplayer is fully optional

Closes #8